### PR TITLE
refactor: add starter pack typings

### DIFF
--- a/src/__tests__/starterPack.types.test.ts
+++ b/src/__tests__/starterPack.types.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import starterPack from '../../starter-pack.v1.json';
+import type { StarterPackJson } from '../types';
+
+describe('starter pack json types', () => {
+  it('conforms to StarterPackJson shape', () => {
+    const sp: StarterPackJson = starterPack;
+    expect(Array.isArray(sp.topics)).toBe(true);
+    const first = sp.topics[0];
+    expect(typeof first.id).toBe('string');
+    expect(typeof first.title).toBe('string');
+    if (first.directions && first.directions.length > 0) {
+      expect(typeof first.directions[0].id).toBe('string');
+      expect(typeof first.directions[0].text).toBe('string');
+    }
+  });
+});

--- a/src/components/StarterPackPicker.tsx
+++ b/src/components/StarterPackPicker.tsx
@@ -1,26 +1,22 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useStore } from '../store';
 import { toast } from '../utils/toast';
-import starterPack from '../../starter-pack.v2.4.json';
+import starterPackData from '../../starter-pack.v2.4.json';
+import type { StarterPackJson, StarterTopicJson } from '../types';
 
-
-interface StarterTopic { 
-  id: string; 
-  title: string; 
-  directions: Array<{ text: string }>;
-}
+const starterPack: StarterPackJson = starterPackData;
 
 export const StarterPackPicker: React.FC = () => {
   const topics = useStore(state => state.topics);
   const addTopicFromStarter = useStore(state => state.addTopicFromStarter);
   const currentFlowStep = useStore(state => state.currentFlowStep);
   const advanceFlowStep = useStore(state => state.advanceFlowStep);
-  const [pool, setPool] = useState<StarterTopic[]>(() => {
-    const raw = (starterPack as { topics: StarterTopic[] }).topics || [];
+  const [pool, setPool] = useState<StarterTopicJson[]>(() => {
+    const raw = starterPack.topics || [];
     return raw.map((t) => ({
       id: t.id,
       title: t.title,
-      directions: (t.directions || []).map((d) => ({ text: d.text }))
+      directions: (t.directions || []).map((d) => ({ id: d.id, text: d.text }))
     }));
   });
   const [isCollapsed, setIsCollapsed] = useState(false);
@@ -36,7 +32,7 @@ export const StarterPackPicker: React.FC = () => {
     }
   }, [topics.length, isCollapsed]);
 
-  const handleAdd = (topic: StarterTopic) => {
+  const handleAdd = (topic: StarterTopicJson) => {
     addTopicFromStarter(topic);
     // Remove from pool so it's not offered again
     setPool(prev => prev.filter(p => p.id !== topic.id));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 // Export all types from a single entry point
 export type * from './diff';
+export type * from './starter-pack';
 
 // Re-export for backward compatibility
 export type { PreferenceSetDiff as TemplateDiff } from './diff';

--- a/src/types/starter-pack.ts
+++ b/src/types/starter-pack.ts
@@ -1,0 +1,17 @@
+export interface StarterDirectionJson {
+  id: string;
+  text: string;
+  [key: string]: unknown;
+}
+
+export interface StarterTopicJson {
+  id: string;
+  title: string;
+  directions?: StarterDirectionJson[];
+  [key: string]: unknown;
+}
+
+export interface StarterPackJson {
+  topics: StarterTopicJson[];
+  [key: string]: unknown;
+}

--- a/src/utils/library.ts
+++ b/src/utils/library.ts
@@ -1,14 +1,12 @@
 // Utilities for building PreferenceSets from compact library mappings
 import type { PreferenceSet } from '../schema';
-import starterPack from '../../starter-pack.v2.4.json';
+import starterPackData from '../../starter-pack.v2.4.json';
+import type { StarterPackJson } from '../types';
 
 type Stars = number; // 0..5
 export type PrefMap = Record<string, Record<string, Stars>>; // topicId -> directionId -> stars
 
-interface StarterPackDirection { id: string; text: string; }
-interface StarterPackTopic { id: string; title: string; importance?: number; directions?: StarterPackDirection[] }
-interface StarterPack { topics: StarterPackTopic[] }
-const sp: StarterPack = (starterPack as StarterPack) || { topics: [] };
+const sp: StarterPackJson = starterPackData;
 
 export const buildPreferenceSetFromPrefs = (title: string, prefs: PrefMap, notes: string = ''): PreferenceSet => {
   const now = new Date().toISOString();

--- a/src/utils/share.ts
+++ b/src/utils/share.ts
@@ -1,17 +1,15 @@
 import { useStore } from '../store';
 import type { Topic } from '../schema';
 // Import the current starter pack to derive a stable index
-import starterPack from '../../starter-pack.v1.json';
+import starterPackData from '../../starter-pack.v1.json';
+import type { StarterPackJson } from '../types';
 
 // Stable pack identifier. Increment when the starter index order changes.
 // Keep older IDs decodable for existing links.
 export const packId = 'sp-v1';
 const allowedPackIds = new Set<string>(['sp-v1', 'sp-v2.4']);
 
-interface StarterPackDirection { id: string; text: string }
-interface StarterPackTopic { id: string; title: string; directions?: StarterPackDirection[] }
-interface StarterPack { topics: StarterPackTopic[] }
-const sp: StarterPack = (starterPack as StarterPack) || { topics: [] };
+const sp: StarterPackJson = starterPackData;
 
 // Build stable indices (append-only ordering)
 export const topicIndex: string[] = sp.topics.map(t => t.id);


### PR DESCRIPTION
## Summary
- centralize starter pack JSON types
- reuse starter pack typings in components and utils
- add unit test verifying starter pack JSON shape

## Testing
- `npm run test:run`

------
https://chatgpt.com/codex/tasks/task_e_68c1609221dc83318d207e7a2a0aef81