### PR TITLE
Update share encoding to starter pack v2.4

### DIFF
--- a/src/__tests__/applyStarterPreferences.test.ts
+++ b/src/__tests__/applyStarterPreferences.test.ts
@@ -81,13 +81,13 @@ describe('applyStarterPreferences', () => {
     const state = useStore.getState();
     expect(state.topics.length).toBe(1); // no duplicates
     expect(state.topics[0].importance).toBe(5);
-    const d = state.topics[0].directions.find(x => x.id === 'dir-f1');
+    const d = state.topics[0].directions.find(x => x.id === d0);
     expect(d?.stars).toBe(2);
   });
 
   it('clamps out-of-range values', () => {
     const ti = directionIndex.findIndex(row => row.length >= 1);
-    const payload = { v: 'sp-v1', tip: [[ti, -2]], dsp: [[ti, 0, 7]] } as any;
+    const payload = { v: 'sp-v2.4', tip: [[ti, -2]], dsp: [[ti, 0, 7]] } as any;
     applyStarterPreferences(payload);
     const t = useStore.getState().topics[0];
     expect(t.importance).toBe(0);

--- a/src/utils/share.ts
+++ b/src/utils/share.ts
@@ -1,12 +1,12 @@
 import { useStore } from '../store';
 import type { Topic } from '../schema';
 // Import the current starter pack to derive a stable index
-import starterPackData from '../../starter-pack.v1.json';
+import starterPackData from '../../starter-pack.v2.4.json';
 import type { StarterPackJson } from '../types';
 
 // Stable pack identifier. Increment when the starter index order changes.
 // Keep older IDs decodable for existing links.
-export const packId = 'sp-v1';
+export const packId = 'sp-v2.4';
 const allowedPackIds = new Set<string>(['sp-v1', 'sp-v2.4']);
 
 const sp: StarterPackJson = starterPackData;
@@ -58,7 +58,7 @@ const b64urlToBytes = (s: string): Uint8Array => {
 };
 
 export interface StarterPayloadDense {
-  v: string;      // pack version, e.g. sp-v1
+  v: string;      // pack version, e.g. sp-v2.4
   ti: number[];   // topic importance per topicIndex
   ds: number[][]; // direction stars per directionIndex row
 }


### PR DESCRIPTION
## Summary
- switch share utilities to use the v2.4 starter pack and update the pack identifier
- align tests with the new starter pack data

## Testing
- npm test -- --run share.sp2
- npm test -- --run applyStarterPreferences

------
https://chatgpt.com/codex/tasks/task_e_68e405b93e748331a8cceb4e132f3719